### PR TITLE
It appears that at some point the lib_obimpact.tavg() method was modi…

### DIFF
--- a/scripts/compare_fsoi.py
+++ b/scripts/compare_fsoi.py
@@ -42,7 +42,7 @@ def load_centers(rootdir,centers,norm,cycle):
             indx = np.ma.logical_or(indx,df.index.get_level_values('DATETIME').hour == c)
         df = df[indx]
 
-        df = loi.tavg(df,level='PLATFORM')
+        df, df_std = loi.tavg(df,level='PLATFORM')
         df = loi.summarymetrics(df)
 
         DF.append(df)
@@ -92,7 +92,7 @@ def main():
             tmp = DF[c][qty]
             tmp.name = center
             tmpdf.append(tmp)
-        df = pd.concat(tmpdf,axis=1)
+        df = pd.concat(tmpdf, axis=1, sort=True)
         df = df.reindex(reversed(platforms))
         loi.comparesummaryplot(df,qty=qty,plotOpt=plotOpt)
 

--- a/scripts/mk_tavgsummary.py
+++ b/scripts/mk_tavgsummary.py
@@ -43,7 +43,7 @@ def main():
     df = loi.accumBulkStats(df)
     platforms = loi.OnePlatform()
     df = loi.groupBulkStats(df,platforms)
-    df = loi.tavg(df,level='PLATFORM')
+    df, df_std = loi.tavg(df,level='PLATFORM')
 
     fpkl = '%s/work/%s/tavg_stats.pkl' % (rootdir,center)
     if os.path.isfile(fpkl):


### PR DESCRIPTION
…fied to return two data frames instead of one.  The call to this method in summary_fsoi.py was updated, but there are two other calls to the method which were not updated.  These are in mk_tavgsummary.py and compare_fsoi.py.  I updated both calls to expect two data frames in return, however, this should be reviewed to make sure the behavior is correct.

Pandas gave one deprecation warning:
/Volumes/JEDI/git/FSOI/scripts/compare_fsoi.py:95: FutureWarning: Sorting because non-concatenation axis is not aligned. A future version
of pandas will change to not sort by default.
To accept the future behavior, pass 'sort=False'.
To retain the current behavior and silence the warning, pass 'sort=True'.
  df = pd.concat(tmpdf, axis=1)

I added a sort=True parameter here to retain the current behavior.