### PR TITLE
Bugfix/issue 32 more disk space on batch

### DIFF
--- a/build/update_lambda.sh
+++ b/build/update_lambda.sh
@@ -10,4 +10,4 @@ cd ../
 
 aws s3 cp $zip_file s3://jcsda-scratch/fsoi_lambda.zip
 aws s3 cp $zip_file s3://jcsda-scratch/$zip_file
-#aws lambda update-function-code --function-name fsoi_request_handler --zip-file fileb://$zip_file
+aws lambda update-function-code --function-name fsoi_request_handler --zip-file fileb://$zip_file

--- a/resources/cloudformation_ios_fsoi_web.yaml
+++ b/resources/cloudformation_ios_fsoi_web.yaml
@@ -322,7 +322,7 @@ Resources:
     Properties:
       Type: MANAGED
       ServiceRole: arn:aws:iam::469205354006:role/service-role/AWSBatchServiceRole
-      ComputeEnvironmentName: fsoi_webapp_env_v2
+      ComputeEnvironmentName: fsoi_webapp_env_v3
       ComputeResources:
         MinvCpus: 8
         MaxvCpus: 24
@@ -334,7 +334,7 @@ Resources:
           - optimal
         # This AMI has a larger LVM partition to allow more storage for the docker containers
         # Some fun reading: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html
-        ImageId: ami-08e2c67002eaf0136
+        ImageId: ami-07ee9fed984790191
         Ec2KeyPair: ios-webapp-batch
         InstanceRole: arn:aws:iam::469205354006:instance-profile/ecsInstanceRole
         Subnets:
@@ -349,7 +349,7 @@ Resources:
     Properties:
       ComputeEnvironmentOrder:
         - Order: 1
-          ComputeEnvironment: fsoi_webapp_env_v2
+          ComputeEnvironment: fsoi_webapp_env_v3
       State: ENABLED
       Priority: 100
       JobQueueName: fsoi_queue

--- a/resources/cloudformation_ios_fsoi_web.yaml
+++ b/resources/cloudformation_ios_fsoi_web.yaml
@@ -367,7 +367,7 @@ Resources:
           - python
           - /batch_wrapper.py
           - Ref::request
-        Memory: 8192
+        Memory: 32768
         JobRoleArn:
           Ref: FsoiBatchRole
         Vcpus: 2

--- a/resources/cloudformation_ios_fsoi_web.yaml
+++ b/resources/cloudformation_ios_fsoi_web.yaml
@@ -322,16 +322,20 @@ Resources:
     Properties:
       Type: MANAGED
       ServiceRole: arn:aws:iam::469205354006:role/service-role/AWSBatchServiceRole
-      ComputeEnvironmentName: fsoi_env
+      ComputeEnvironmentName: fsoi_webapp_env_v2
       ComputeResources:
-        MinvCpus: 2
+        MinvCpus: 8
         MaxvCpus: 24
-        DesiredvCpus: 2
+        DesiredvCpus: 8
         SecurityGroupIds:
           - Ref: BatchEnvSecurityGroup
         Type: EC2
         InstanceTypes:
           - optimal
+        # This AMI has a larger LVM partition to allow more storage for the docker containers
+        # Some fun reading: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ami-storage-config.html
+        ImageId: ami-08e2c67002eaf0136
+        Ec2KeyPair: ios-webapp-batch
         InstanceRole: arn:aws:iam::469205354006:instance-profile/ecsInstanceRole
         Subnets:
           - Ref: BatchEnvSubnet
@@ -345,7 +349,7 @@ Resources:
     Properties:
       ComputeEnvironmentOrder:
         - Order: 1
-          ComputeEnvironment: fsoi_env
+          ComputeEnvironment: fsoi_webapp_env_v2
       State: ENABLED
       Priority: 100
       JobQueueName: fsoi_queue

--- a/scripts/lambda_wrapper.py
+++ b/scripts/lambda_wrapper.py
@@ -132,7 +132,7 @@ def send_cached_response(req_hash, client_url):
     :return: None
     """
     key_list = get_cached_object_keys(req_hash)
-    response = create_response_body(key_list, req_hash)
+    response = create_response_body(key_list, req_hash, [])
     send_response(response, client_url)
 
 

--- a/scripts/lambda_wrapper.py
+++ b/scripts/lambda_wrapper.py
@@ -86,7 +86,7 @@ def submit_request(request, hash_value, client_url, ref_id):
     res = batch.submit_job(
         jobName=hash_value,
         jobQueue='fsoi_queue',
-        jobDefinition='fsoi_job:8',
+        jobDefinition='fsoi_job:9',
         parameters={'request': json.dumps(request)}
     )
     submitted = res['ResponseMetadata']['HTTPStatusCode'] == 200


### PR DESCRIPTION
This change references a new AMI to process the user requests in AWS Batch.  Changes in the AMI were to include a larger (200 GB) disk, create an LVM partition with additional disk space, and add the new partition to the LVM docker group.  Also updated /etc/sysconfig/docker-storage to provide 178 GB of disk space to each docker container.