### PR TITLE
fix for wheelzoom warning message

### DIFF
--- a/python/src/fsoi/plots/compare_fsoi.py
+++ b/python/src/fsoi/plots/compare_fsoi.py
@@ -111,7 +111,7 @@ def bokehcomparesummaryplot(df, palette, qty='TotImp', plot_options=None):
         plot_height=800,
         y_range=list(df.index.unique()),
         x_range=x_range,
-        tools='pan,hover,wheel_zoom,xwheel_zoom,box_zoom,save,reset',
+        tools='pan,hover,wheel_zoom,box_zoom,save,reset',
         toolbar_location='right',
         tooltips=tooltips
     )

--- a/python/src/fsoi/plots/summary_fsoi.py
+++ b/python/src/fsoi/plots/summary_fsoi.py
@@ -290,7 +290,7 @@ def bokehsummaryplot(df, qty='TotImp', plot_options=None, std=None):
         plot_height=800,
         y_range=list(df1.index.unique()),
         x_range=x_range,
-        tools='pan,hover,wheel_zoom,xwheel_zoom,box_zoom,save,reset',
+        tools='pan,hover,wheel_zoom,box_zoom,save,reset',
         toolbar_location='right',
         tooltips=tooltips
     )


### PR DESCRIPTION
## Description
This PR fixes a warning message that was being produced for bokeh plots. The xwheel_zoom (x-axis only) functionality is already contemplated by the wheel_zoom (both axis).

### Issue(s) addressed
- fixes #118 

## Dependencies
None

## Impact
None