### PR TITLE
minor typo in the header

### DIFF
--- a/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
+++ b/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
@@ -1,4 +1,4 @@
-# This file contains constant values used to download and process NRL data
+# This file contains constant values used to download and process GMAO data
 ---
 lag_in_days: 3
 processed_data_bucket: fsoi


### PR DESCRIPTION
## Description
Fix a minor typo in the header of the GMAO ingest yaml file.

### Issue(s) addressed
- fixes #130

## Dependencies
None

## Impact
None