### PR TITLE
Changed github URL to JCSDA-internal.

### DIFF
--- a/python/src/fsoi/resources/cloudformation_codebuild.yaml
+++ b/python/src/fsoi/resources/cloudformation_codebuild.yaml
@@ -143,7 +143,7 @@ Resources:
       Source:
         BuildSpec: buildspec.yml
         Type: GITHUB
-        Location: https://github.com/JCSDA/FSOI
+        Location: https://github.com/JCSDA-internal/FSOI
         ReportBuildStatus: true
       TimeoutInMinutes: 120  # 2 hours
       Triggers:


### PR DESCRIPTION
## Description

Fixes a CodeBuild project that broke after JCSDA was renamed to JCSDA-internal on github.