### PR TITLE
Adding CrIS-FSR N20 for NRL FSOI data ingestion

### DIFF
--- a/python/src/fsoi/ingest/nrl/nrl_ingest.yaml
+++ b/python/src/fsoi/ingest/nrl/nrl_ingest.yaml
@@ -95,6 +95,7 @@ kx:
   210: AMSUA
   250: SSMI_TPW
   251: WINDSAT_TPW
+  296: CrIS
 kt:
   1:
     - z


### PR DESCRIPTION
## Description
AWS started reporting unknown platforms for NRL on May 10th, 2021, related to the analysis cycle of May 6th, 2021 (lagged processing). The unknown platform presents platform ID 296. According to Rolf Langland, this platform is for CrIS-FSR N20. This PR is adding this observation type for NRL.

### Issue(s) addressed
- fixes #145

## Dependencies
None

## Impact
None

## Test Data
None