### PR TITLE
Replacing requires with install_requires

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -12,9 +12,9 @@ setup(
   packages=['fsoi', 'fsoi.data', 'fsoi.ingest', 'fsoi.ingest.emc', 'fsoi.ingest.gmao', 'fsoi.ingest.jma',
             'fsoi.ingest.met', 'fsoi.ingest.meteofr', 'fsoi.ingest.nrl', 'fsoi.plots', 'fsoi.stats',
             'fsoi.web', 'fsoi.ingest.merra'],
-  requires=['bokeh==1.4.0', 'pyyaml', 'boto3', 'botocore', 'certifi',
-            'matplotlib', 'numpy', 'pandas', 'requests',
-            'urllib3', 'tables', 'fortranformat', 'netCDF4', 'phantomjs', 'selenium'],
+  install_requires=['bokeh==1.4.0', 'pyyaml', 'boto3', 'botocore', 'certifi',
+                    'matplotlib', 'numpy', 'pandas', 'requests',
+                    'urllib3', 'tables', 'fortranformat', 'netCDF4', 'phantomjs', 'selenium'],
   package_dir={'fsoi': 'src/fsoi'},
   package_data={
     'fsoi': [


### PR DESCRIPTION
## Description
I noticed that the code is crashing when installing these FSOI tools. Apparently, the crash is because the `requires` key doesn't allow to specify version numbers for those packages. This can be achieved by replacing `requires` with the `install_requires`.

This PR is replacing the `requires` key with the `install_requires` key to allow the specification of versions among the packages (e.g., 1.4.0 version of the bokeh package).

## Dependencies
None

## Impact
None