### PR TITLE
Adding missing observation types for NRL and MET

### DIFF
--- a/python/src/fsoi/ingest/met/met_ingest.yaml
+++ b/python/src/fsoi/ingest/met/met_ingest.yaml
@@ -45,6 +45,10 @@ kt:
   - ba
   - Bending Angle
   - N
+  98:
+  - hlos
+  - Horizontal Line Of Sight
+  - m/s
 platforms:
   observation_types_for_radiance:
     - 10
@@ -210,6 +214,7 @@ platforms:
       - GPM1 GMILOW
       - GPM1 GMIHIGH
     HLOSWind:
+      - HLOSWIND 48
       - HLOSWIND 48 18
       - HLOSWIND48 10
       - HLOSWIND48 11

--- a/python/src/fsoi/ingest/nrl/process_nrl.py
+++ b/python/src/fsoi/ingest/nrl/process_nrl.py
@@ -173,7 +173,10 @@ def _get_platform_channel(instyp, schar, kx, uknownplats):
             channel = ichan
 
     elif platform in ['CrIS']:
-        platform = '%s_NPP' % platform
+        if 'NPP' in schar:
+            platform = '%s_NPP' % platform
+        elif 'NOAA20' in schar:
+            platform = '%s_N20' % platform
         ichan = 0
         chanmin, chanmax = 1, 1143
         for ichan in range(chanmin, chanmax):
@@ -349,7 +352,7 @@ def main():
     parser.add_argument('-d', '--date', help='analysis date to process', metavar='YYYYMMDDHH',
                         required=True)
     args = parser.parse_args()
-    
+
     # prepare the working directory
     # prepare the processing parameters
     date = args.date

--- a/python/src/fsoi/platforms.yaml
+++ b/python/src/fsoi/platforms.yaml
@@ -363,6 +363,7 @@ NRL:
   Buoy:
     - Drifting_Buoy
   CrIS:
+    - CrIS_N20
     - CrIS_NPP
   Dropsonde:
     - Dropsonde
@@ -484,6 +485,8 @@ MET:
   HIRS:
     - HIRS_METOP-A
     - HIRS_METOP-B
+  HLOSWind:
+    - HLOSWind
   IASI:
     - IASI_METOP-A
     - IASI_METOP-B
@@ -673,6 +676,7 @@ OnePlatform:
   CrIS:
     - CRIS_NPP
     - CrIS_NPP
+    - CrIS_N20
     - CRIS-FSR_N20
     - CrIS_N20
   Dropsonde:


### PR DESCRIPTION
## Description
This PR is adding missing observation types for NRL (CrIS-FSR N20) and MET (HLOSwind).

### Issue(s) addressed
- fixes #158 

## Dependencies
None

## Impact
None