### PR TITLE
Adding the Kompsat and Paz IDs (kxs) for GMAO ingestion of FSOI data

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -8,7 +8,7 @@ install: egg
 
 aws_lambda:
 	rm -Rf artifact_build && mkdir artifact_build
-	cd artifact_build; pip3 install -t . chardet requests urllib3 certifi idna pandas pytz six pyyaml matplotlib pyparsing cycler kiwisolver numexpr mock tables
+	cd artifact_build; pip3 install -t . chardet==3.0.4 requests==2.23.0 urllib3==1.25.9 certifi==2020.4.5.1 idna==2.9 pandas==1.0.3 pytz==2020.1 six==1.14.0 pyyaml==5.3.1 matplotlib==3.2.1 pyparsing==2.4.7 cycler==0.10.0 kiwisolver==1.2.0 numexpr==2.7.1 Pillow==7.1.2 tables==3.6.1
 	cd artifact_build; rm -Rf *.dist-info __pycache__ bin setuptools
 	cd artifact_build; pwd
 	cd artifact_build; cp -R ../../python/src/fsoi .

--- a/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
+++ b/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
@@ -93,6 +93,7 @@ kx:
   5: GPSRO
   42: GPSRO
   43: GPSRO
+  44: GPSRO
   112: TCBogus
   120: Radiosonde
   130: AIREP
@@ -151,3 +152,4 @@ kx:
   755: GPSRO_COSMIC_2
   786: CNOFS_GPSRO_bending_angles
   820: SACC_GPSRO_bending_angles
+  825: GPSRO


### PR DESCRIPTION
## Description
This PR is adding the Kompsat and Paz IDs (kx) for GMAO ingestion of FSOI data.

### Issue(s) addressed
- fixes #168

## Acceptance Criteria (Definition of Done)
No "unknown" platforms are reported when decoding GMAO FSOI data.

## Dependencies
None

## Impact
None