### PR TITLE
A few adjustments for GMAO's latest upgrade

### DIFF
--- a/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
+++ b/python/src/fsoi/ingest/gmao/gmao_ingest.yaml
@@ -59,6 +59,10 @@ kt:
     - Tv
     - Upper-air virtual temperature
     - K
+  87:
+    - mix_o3
+    - Ozone mixing ratio
+    - ppmv
   89:
     - ba
     - Bending Angle

--- a/python/src/fsoi/ingest/gmao/process_gmao.py
+++ b/python/src/fsoi/ingest/gmao/process_gmao.py
@@ -292,7 +292,7 @@ def process_gmao(norm, date=None, path=None):
 
             obtype = kt[ods.kt[o]][0]
 
-            channel = -999 if platform in ['CONV'] else np.int(ods.lev[o])
+            channel = -999 if platform in ['CONV'] else int(ods.lev[o])
             lon = ods.lon[o] if ods.lon[o] >= 0.0 else ods.lon[o] + 360.0
             lat = ods.lat[o]
             if obtype == 'ps':

--- a/python/src/fsoi/platforms.yaml
+++ b/python/src/fsoi/platforms.yaml
@@ -652,12 +652,14 @@ OnePlatform:
   ATMS:
     - ATMS_NPP
     - ATMS_N20
-    - ATMS_N20
+  AVHRR:
+    - AVHRR_METOP-A
+    - AVHRR_METOP-B
+    - AVHRR_N18
+    - AVHRR_N19
   AVHRR Wind:
     - AVHRR_Wind
     - AMV-AVHRR
-    - AVHRR_METOP-A
-    - AVHRR_N18
   Aircraft:
     - AIREP
     - AMDAR
@@ -677,6 +679,7 @@ OnePlatform:
     - CRIS_NPP
     - CrIS_NPP
     - CRIS-FSR_N20
+    - CRIS-FSR_NPP
     - CrIS_N20
   Dropsonde:
     - Dropsonde
@@ -707,6 +710,8 @@ OnePlatform:
     - GPSRO
     - GPSRO_COSMIC_2
     - GNSSRO
+    - CNOFS_GPSRO_bending_angles
+    - SACC_GPSRO_bending_angles
   Geo Wind:
     - GEO_Wind
     - Sat_Wind
@@ -717,10 +722,9 @@ OnePlatform:
   GMI:
     - GMI_GPM
     - GMI
+    - GPM1_GMI
   GNSSDELAY:
     - GNSSDELAY
-  GPM_GMI:
-    - GPM1_GMI
   HIRS:
     - HIRS4_N18
     - HIRS4_NOAA18
@@ -763,6 +767,8 @@ OnePlatform:
     - MHS_METOP-B
     - MHS_Metop-B
     - MHS_METOP-C
+  MLS:
+    - MLS55_AURA
   MODIS Wind:
     - MODIS_Wind
     - AMV-MODIS
@@ -812,6 +818,7 @@ OnePlatform:
     - SSMIS_DMSP-F18
     - F17_SSMIS
   SEVIRI:
+    - SEVIRI_M08
     - SEVIRI_M10
     - SEVIRI
     - Seviri


### PR DESCRIPTION
## Description
This PR is:
- adding ozone mixing layer into the list of variables being assimilated;
- replacing the usage of `numpy.int` with `int` to remove a warning in the `python/src/fsoi/ingest/gmao/process_gmao.py`;
- adding `CRIS-FSR_NPP` as one of options for CrIS;
- adding the `AVHRR` class to hold brightness temperatures only and keeping `AVHRR winds` to hold horizontal wind components only;
- merging GMI-based observing systems into a single class;
- adding the MLS class;
- adding `SEVIRI_M08` as one of the options for `Seviri`;

### Issue(s) addressed
- fixes TO-BE-CREATED

## Acceptance Criteria (Definition of Done)
No `Unknown` classes appear for GMAO.

## Dependencies
None

## Impact
None